### PR TITLE
Fix form issues w/ radio buttons

### DIFF
--- a/zootable/zoo_checks/templates/animal_form_snippet.html
+++ b/zootable/zoo_checks/templates/animal_form_snippet.html
@@ -9,13 +9,14 @@
 <br />{{anim.identifier}}
 </td>
 
-<td id="{{anim.species.common_name|cut:" "}}_animal_condition_form">
+<td id="species_{{anim.species.id}}_animal_condition_form">
 
 {% for hidden in form.hidden_fields %}
+    {{ hidden.errors }}
     {{ hidden }}
 {% endfor %}
 
-{% include "condition_form_snippet.html"  with field=form.condition %}
+{% include "condition_form_snippet.html" with field=form.condition %}
 
 </td>
 {% for pcond in prior_conditions %}

--- a/zootable/zoo_checks/templates/condition_form_snippet.html
+++ b/zootable/zoo_checks/templates/condition_form_snippet.html
@@ -1,3 +1,5 @@
+{% load template_tags %}
+
 <div class="fieldWrapper condition-radio">
     {% for radio in field %}
         <span>
@@ -7,6 +9,8 @@
         </label>
         </span>
     {% endfor %}
+
+    {{field|hidden_initial_field}}
 
     {% for error in field.errors %}
         <span class="help-block {{ form.error_css_class }}">{{ error }}</span>

--- a/zootable/zoo_checks/templates/species_count_form_snippet.html
+++ b/zootable/zoo_checks/templates/species_count_form_snippet.html
@@ -10,7 +10,7 @@
     </b><br/>
     <em>({{species.genus_name}} {{species.species_name}})</em>
 </td>
-<td id="{{species.common_name|cut:" "}}_form">
+<td id="species_{{species.id}}_form">
     {% if not group_form %}
         {% for field in form.hidden_fields %}
             {{field}}

--- a/zootable/zoo_checks/templatetags/template_tags.py
+++ b/zootable/zoo_checks/templatetags/template_tags.py
@@ -29,3 +29,8 @@ def addDays(days, start_date=None):
 
     newDate = start_date + datetime.timedelta(days=days)
     return newDate
+
+
+@register.filter()
+def hidden_initial_field(field):
+    return field.as_hidden(only_initial=True)


### PR DESCRIPTION
This PR fixes two issues
1. fix initial hidden radio wasn't rendered
1. fix special chars in css selector for js

The first bug has been longstanding.  
- The problem was that deselecting radio buttons weren't recognized as "changed data".  
- That led to discovering that despite the fact that we had `show_hidden_initial=True` for the condition field, we weren't rendering the hidden initial form that allows django to detect changes, because we have been custom rendering the radio buttons for styling.
- Adding the hidden initial form was challenging, and I discovered two ways to do it:

1. change the widget to a custom widget 

`forms.py`

``` python
def CustomRadioSelect(RadioSelect):
    template_name = "custom_radio.html"
```

`templates/custom_radio.html`

``` html
{% with id=widget.attrs.id %}
    {% for group, options, index in widget.optgroups %}
        {% for option in options %}
            <span>
                <label>
                    <input type="radio" name="{{id}}" value="{{option.value}}"
                    {% include "django/forms/widgets/attrs.html" with widget=option %}>
                    <span>{{ option.label }}</span>
                </label>
            </span>
        {% endfor %}
    {% endfor %}
{% endwith %}
```

This worked, but was clunky in my opinion.

2. Force render the hidden initial form. This was a problem for a while, because I couldn't figure out where it was being rendered (it's not explicitly in the widget code). I finally discovered where this gets called: [boundfield.py](https://github.com/django/django/blob/d89053585e11e869efcc9debb1c311b47b5e20ea/django/forms/boundfield.py#L32)  Once I saw how that method was being called, it was pretty straightforward -- I created a templatetag (in order to pass the `only_initial=True` arg to the `as_hidden` method on the field), and then you can easily render the hidden initial field in the template.  This seemed better in my case, mainly because it was less code and I was skeptical I had correctly deciphered the widget code in option 1.

The second bug was new, and we just now use id instead of the common name for a css selector, because the common names can have special characters in them and that can cause challenges for the selector in JS.